### PR TITLE
containers to ignore read from the AWS user data yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
 FROM belly/buildstep
-ADD . /app
+
+# Run build against Gemfile first so subsequent builds are much faster
+ADD Gemfile /app/Gemfile
+ADD Gemfile.lock /app/Gemfile.lock
 RUN /build/builder
+
+ADD . /app
 CMD /start clock


### PR DESCRIPTION
@bellycard/infrastructure 
DO NOT MERGE

We need to determine the key that will be written in the user data that can be read from a container's configuration that will be used to "ignore" known system services
