### PR TITLE
UUIDs for service ids

### DIFF
--- a/clock.rb
+++ b/clock.rb
@@ -32,9 +32,9 @@ handler do |job|
       puts e.message
     end
   when 'report_self_to_health_check'
-    @service_names.each do |service_name|
+    @service_ids.each do |service_id|
       begin
-        check_id = "service:#{service_name}"
+        check_id = "service:#{service_id}"
         ConsulApi::Agent.check_pass(check_id)
       rescue => e
         puts e.message
@@ -45,14 +45,15 @@ end
 
 
 def register_self
-  @service_names.each do |service_name|
+  @service_names.each_with_index do |service_name, index|
     # de-register all services on this agent (in case there's a stale service)
-    ConsulApi::Agent.service_deregister(service_name)
+    ConsulApi::Agent.service_deregister(@service_ids[index])
 
     # register this as a service on the consul agent
     service_hash =
       {
         'Name' => service_name,
+        'ID' => @service_ids[index],
         'Tags' => [
 
         ],
@@ -74,6 +75,7 @@ end
 
 # no aws?  no problem.  Assume that this is development machine, and support builds and api
 @service_names = ['jockey-api-development', 'jockey-build-development']
+@service_ids = []
 @system_services = []
 begin
   # if you're using AWS, you can query the user data for what kind of deploys this can take
@@ -87,6 +89,10 @@ begin
 rescue => e
   puts 'unable to get aws user data'
   puts e.message
+end
+
+@service_names.each do |service|
+  @service_ids << SecureRandom.uuid
 end
 
 register_self


### PR DESCRIPTION
@bellycard/infrastructure 
this will prevent conflicts from happening across consul for the service ids.  THIS WILL have the side affect of IF docker_consul_update restarts, it will create additional services (same name, but different ID).  Old ones will health check to critical.  This should keep a balance correct, but will be cray-cray if it finds a restart-loop.
